### PR TITLE
add homebrew installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Make sure you have rbenv 0.4.0 or later, then run:
 
     git clone https://github.com/sstephenson/rbenv-gem-rehash.git ~/.rbenv/plugins/rbenv-gem-rehash
 
+### Or on Mac OS X with Homebrew
+
+`brew install rbenv-gem-rehash`
+
 ## Usage
 
 1. `gem install` a gem that provides executables.


### PR DESCRIPTION
I contributed a formula to Homebrew to install rbenv-gem-rehash, so I added installation instructions to the README.md file for that.