### PR TITLE
Only execute rbenv rehash if the shims directory is writable

### DIFF
--- a/rubygems_plugin.rb
+++ b/rubygems_plugin.rb
@@ -4,5 +4,8 @@ hook = lambda do |installer|
   end
 end
 
-Gem.post_install(&hook)
-Gem.post_uninstall(&hook)
+shims_path = File.join(ENV['RBENV_ROOT'], "shims")
+if File.writable?(shims_path)
+  Gem.post_install(&hook)
+  Gem.post_uninstall(&hook)
+end


### PR DESCRIPTION
This removes the `rbenv: cannot rehash: /usr/local/share/rbenv/shims isn't writable` warning when running `bundle install` in a system-wide rbenv installation.
