### PR TITLE
Work around Rubinius build script choking on RUBYLIB

### DIFF
--- a/etc/rbenv.d/exec/~gem-rehash.bash
+++ b/etc/rbenv.d/exec/~gem-rehash.bash
@@ -2,8 +2,10 @@
 cwd="$PWD"
 cd "${BASH_SOURCE%/*}/../../.."
 
-# Make sure `rubygems_plugin.rb` is discovered by RubyGems by adding
-# its directory to Ruby's load path.
-export RUBYLIB="$PWD:$RUBYLIB"
+if [ "$2" != "./configure" ]; then
+  # Make sure `rubygems_plugin.rb` is discovered by RubyGems by adding
+  # its directory to Ruby's load path.
+  export RUBYLIB="$PWD:$RUBYLIB"
+fi
 
 cd "$cwd"


### PR DESCRIPTION
Rubinius' `./configure` script is has a guard that aborts the build if RUBYLIB environment variable is set. As an unfortunate consequence, anybody using "rbenv-gem-rehash" plugin won't be able to build Rubinius.

This works around the issue by not writing to RUBYLIB if the name of the script to be executed is `./configure`. Granted, this might affect more projects than just Rubinius, but this assumes that a script named `./configure` won't install any gems that need to be rehashed afterwards.

This is a terrible thing to do, but I don't see a cleaner workaround.

Fixes #8. Also see rubinius/rubinius#2659
